### PR TITLE
Exercise 2: implement accrued_interest calculation for bond pricing

### DIFF
--- a/src/bond_price.py
+++ b/src/bond_price.py
@@ -2,8 +2,27 @@ from bond_cashflows import cashflows
 from datetime import datetime
 import numpy as np
 import pandas as pd
+from typing import Union
 
-def accrued_interet(cf_df,issue_date:str| pd.Timestamp, settle_date:str| pd.Timestamp,coupon_rate:float, frequency:int, nominal: float) -> float:
+def price_dirty(cf_df, settle_date: Union [str,pd.Timestamp],yld: float) -> float:
+
+    settle_date = pd.to_datetime(settle_date)
+    
+    future_cf = cf_df[cf_df['Dates'] > settle_date]
+    cashflows = future_cf['Cashflows']
+    dates = future_cf['Dates']
+    t_list = [(date - settle_date).days/365 for date in dates]
+
+
+    dirty_price = sum(c/((1+yld)**t) for c,t in zip(cashflows,t_list))
+    
+    return dirty_price
+
+
+
+
+
+def accrued_interest(cf_df,issue_date: Union [str, pd.Timestamp], settle_date:Union [str, pd.Timestamp],coupon_rate:float, frequency:int, nominal: float) -> float:
     
     df_Dates = cf_df['Dates']
     settle_date = pd.to_datetime(settle_date)
@@ -17,10 +36,17 @@ def accrued_interet(cf_df,issue_date:str| pd.Timestamp, settle_date:str| pd.Time
     ai = coupon * ((settle_date - last_coupon).days/(next_coupon-last_coupon).days)
     return ai
 
+
+
+def price_clean(dirty: float, accrued: float) -> float:
+    return dirty - accrued
+
 if __name__ == '__main__':
     df = cashflows('2022-02-20','2025-03-25',0.05,2,nominal=1000)
-    af = accrued_interet(df,'2022-02-20','2022-03-20',0.05,2,nominal=1000)
-    print(af)
+    df_dirty = price_dirty(df,'2023-03-20',0.05)
+    df_ai = accrued_interest(df, '2022-02-20', '2023-03-20', 0.05, 2, nominal=1000)
+    df_clean = price_clean(df_dirty,df_ai)
+    print(df_clean)
 
 
 

--- a/src/bond_price.py
+++ b/src/bond_price.py
@@ -1,0 +1,28 @@
+from bond_cashflows import cashflows
+from datetime import datetime
+import numpy as np
+import pandas as pd
+
+def accrued_interet(cf_df,issue_date:str| pd.Timestamp, settle_date:str| pd.Timestamp,coupon_rate:float, frequency:int, nominal: float) -> float:
+    
+    df_Dates = cf_df['Dates']
+    settle_date = pd.to_datetime(settle_date)
+    issue_date = pd.to_datetime(issue_date)
+    
+    last_coupon = df_Dates[df_Dates <= settle_date].iloc[-1] if not df_Dates[df_Dates <= settle_date].empty else issue_date
+
+    next_coupon = df_Dates[df_Dates > settle_date].iloc[0]
+
+    coupon = (nominal * coupon_rate )/frequency
+    ai = coupon * ((settle_date - last_coupon).days/(next_coupon-last_coupon).days)
+    return ai
+
+if __name__ == '__main__':
+    df = cashflows('2022-02-20','2025-03-25',0.05,2,nominal=1000)
+    af = accrued_interet(df,'2022-02-20','2022-03-20',0.05,2,nominal=1000)
+    print(af)
+
+
+
+
+

--- a/src/bond_price.py
+++ b/src/bond_price.py
@@ -4,14 +4,37 @@ import numpy as np
 import pandas as pd
 from typing import Union
 
-def price_dirty(cf_df, settle_date: Union [str,pd.Timestamp],yld: float) -> float:
+
+"""
+Exercise 2
+===========================
+Dirty price, accrued interest and clean price for a fixed-rate bullet bond.
+
+We re-use the `cashflows` function from bond_cashflows.py (Exercise 1).
+
+Conventions
+-----------
+* `yld` is an annual yield in decimal (e.g. 0.0375 = 3.75 %).
+* Present-value day-count: ACT/365.25 (simple).
+* Accrued-interest day-count: ACT/ACT ICMA.
+"""
+
+
+# ---------------------------------------------------------------------
+# 1. Dirty price
+# ---------------------------------------------------------------------
+
+def price_dirty(cf_df:pd.DataFrame, settle_date: Union [str,pd.Timestamp],yld: float) -> float:
 
     settle_date = pd.to_datetime(settle_date)
     
     future_cf = cf_df[cf_df['Dates'] > settle_date]
+    if future_cf.empty:
+        return 0.0
+
     cashflows = future_cf['Cashflows']
     dates = future_cf['Dates']
-    t_list = [(date - settle_date).days/365 for date in dates]
+    t_list = [(date - settle_date).days/365.25 for date in dates]
 
 
     dirty_price = sum(c/((1+yld)**t) for c,t in zip(cashflows,t_list))
@@ -20,9 +43,11 @@ def price_dirty(cf_df, settle_date: Union [str,pd.Timestamp],yld: float) -> floa
 
 
 
+# ---------------------------------------------------------------------
+# 2. Accrued interest (coupon couru)
+# ---------------------------------------------------------------------
 
-
-def accrued_interest(cf_df,issue_date: Union [str, pd.Timestamp], settle_date:Union [str, pd.Timestamp],coupon_rate:float, frequency:int, nominal: float) -> float:
+def accrued_interest(cf_df:pd.DataFrame,issue_date: Union [str, pd.Timestamp], settle_date:Union [str, pd.Timestamp],coupon_rate:float, frequency:int, nominal: float) -> float:
     
     df_Dates = cf_df['Dates']
     settle_date = pd.to_datetime(settle_date)
@@ -32,22 +57,34 @@ def accrued_interest(cf_df,issue_date: Union [str, pd.Timestamp], settle_date:Un
 
     next_coupon = df_Dates[df_Dates > settle_date].iloc[0]
 
+
+
     coupon = (nominal * coupon_rate )/frequency
     ai = coupon * ((settle_date - last_coupon).days/(next_coupon-last_coupon).days)
     return ai
 
 
 
+
+# ---------------------------------------------------------------------
+# 3. Clean price
+# ---------------------------------------------------------------------
 def price_clean(dirty: float, accrued: float) -> float:
     return dirty - accrued
 
+
+
+
+# ---------------------------------------------------------------------
+# 4.test 
+# ---------------------------------------------------------------------
+
 if __name__ == '__main__':
-    df = cashflows('2022-02-20','2025-03-25',0.05,2,nominal=1000)
-    df_dirty = price_dirty(df,'2023-03-20',0.05)
-    df_ai = accrued_interest(df, '2022-02-20', '2023-03-20', 0.05, 2, nominal=1000)
+    df = cashflows('2024-01-01','2029-01-01',0.05,1,nominal=1000)
+    df_dirty = price_dirty(df,'2024-09-01',0.05)
+    df_ai = accrued_interest(df, '2024-01-01', '2024-09-01', 0.05, 1, nominal=1000)
     df_clean = price_clean(df_dirty,df_ai)
     print(df_clean)
-
 
 
 


### PR DESCRIPTION
Starting work on Exercise 2: pricing bonds with a flat yield.

Planned functions:
- `price_dirty`: computes dirty price from cashflows and yield
- `accrued_interest`: computes accrued interest based on settlement date
- `price_clean`: computes clean price from dirty price and accrued interest